### PR TITLE
fix(scorecard): npm ci in verify-vendor for Pinned-Dependencies 10/10

### DIFF
--- a/scripts/verify-vendor.sh
+++ b/scripts/verify-vendor.sh
@@ -74,7 +74,7 @@ tar xzf src.tar.gz
 cd "happy-dom-$commit/packages/happy-dom"
 
 echo "Building deterministic bundle..."
-npm install --silent
+npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts --silent
 SOURCE_DATE_EPOCH=1700000000 \
   ./node_modules/.bin/esbuild --bundle src/index.ts \
   --format=esm \


### PR DESCRIPTION
Uses npm ci (lockfile-based) instead of npm install in verify-vendor.sh. Addresses the last Scorecard Pinned-Dependencies warning.