### PR TITLE
fix(ci): build radamsa from source on ubuntu-latest

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,8 +17,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install radamsa
-        run: sudo apt-get update && sudo apt-get install -y radamsa
+      - name: Install radamsa (build from source)
+        # apt install radamsa started failing on ubuntu-latest in 2026-Q2 —
+        # the package is in universe and the github-hosted runner image no
+        # longer enables that pocket on every minor version. Build radamsa
+        # ourselves; its ~10s and pin-stable to the upstream tag.
+        run: |
+          git clone --depth 1 --branch v0.6 https://gitlab.com/akihe/radamsa.git /tmp/radamsa
+          cd /tmp/radamsa
+          make
+          sudo make install
+          radamsa --version
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary

- `apt-get install -y radamsa` started returning `Unable to locate package radamsa` on ubuntu-latest from 2026-04-26 onward — package lives in `universe` and the github-hosted runner image no longer guarantees universe is enabled on every minor version
- Replace apt path with a 10-second source build pinned to upstream tag `v0.6`
- Restores nightly Fuzz workflow

## Test plan

- [ ] Workflow run on this PR's branch succeeds (radamsa builds, `radamsa --version` prints)
- [ ] After merge, next nightly cron at 04:00 UTC runs green