### PR TITLE
fix(blocklist): close radamsa bypass paths via token-anywhere patterns

### DIFF
--- a/skills/chrome-multi-profile/chrome-lib.sh
+++ b/skills/chrome-multi-profile/chrome-lib.sh
@@ -1161,19 +1161,29 @@ chrome_restore() {
 
 # URL blocklist (readonly, NOT overridable) — NFR-SR-2
 readonly -a CHROME_URL_BLOCKLIST=(
-  "*/checkout*"
-  "*/payment*"
-  "*/billing*"
-  "*/subscribe*"
-  "*/upgrade*"
-  "*/cart/*"
-  "*/gp/buy/*"
-  "*checkout.stripe.com/*"
-  "*.paypal.com/checkout/*"
-  "*buy.stripe.com/*"
-  "*pay.google.com/*"
-  "*account.proton.me/*upgrade*"
-  "*account.proton.me/*dashboard*"
+  # Token-anywhere patterns — match the token in any URL position, including
+  # mutations where the path separator was rewritten to a dot or a Unicode
+  # confusable was injected. T056 nightly fuzz (radamsa) confirms this catches
+  # all 1000 mutations vs the prior `*/checkout*`-style patterns that bypassed
+  # on `https://example.com.subscribe/premium` and similar.
+  #
+  # Tradeoff: more aggressive over-block on benign URLs that happen to contain
+  # these tokens (e.g. `news.example.com/upgrade-tips`). The plugin's contract
+  # is human-confirm-before-action — an over-block costs one extra prompt; an
+  # under-block costs an unintended payment.
+  "*checkout*"
+  "*payment*"
+  "*billing*"
+  "*subscribe*"
+  "*upgrade*"
+  "*cart*"
+  "*gp/buy*"
+  "*checkout.stripe.com*"
+  "*paypal.com/checkout*"
+  "*buy.stripe.com*"
+  "*pay.google.com*"
+  "*account.proton.me*upgrade*"
+  "*account.proton.me*dashboard*"
   "*accounts.google.com/signin*"
 )
 


### PR DESCRIPTION
## Summary

T056 nightly fuzz (radamsa, 1000 mutations) found 26 bypasses on the URL blocklist after #30 unblocked the fuzz harness. Cause: path-segment glob patterns (`*/checkout*`) require a literal `/` separator that radamsa rewrites or pads with zero-width Unicode.

Fix: switch to token-anywhere patterns (`*checkout*`). Same security posture against real-world URLs, robust against mutation.

## Bypass examples (now blocked)

```
https://example.com.subscribe/premium      ← `.` instead of `/`
https://www.paypal.checkout/review         ← subdomain mutation
https://example.com/󠀥checkout/cart          ← zero-width Unicode confusable
```

## Verification

```
$ bash tests/fuzz/radamsa-urls.sh
PASS: 1000 radamsa mutations exercised without bypass

$ bats tests/bats/01-url-blocklist.bats
1..26
26 tests, 0 failures
```

All 26 bats tests pass — including #22 `similar-but-safe URL (chase.com) is allowed` (chase.com contains no danger token, so loose patterns don't over-match).

## Tradeoff

Over-block surface is now bounded to URLs that literally contain a danger token in any position. E.g. `news.example.com/upgrade-tips` would be blocked. Plugin contract is human-confirm-before-action — over-block costs one prompt, under-block costs an unintended payment. Inline comment documents the call.

## Test plan

- [x] Local fuzz: 1000 radamsa mutations PASS
- [x] Local bats: 26 tests PASS
- [ ] CI: Fuzz workflow on this PR's branch passes
- [ ] CI: bats workflow passes

Closes #31.