### PR TITLE
fix(integration): mark playwright suite as ESM

### DIFF
--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -2,6 +2,7 @@
   "name": "claude-mac-chrome-integration",
   "version": "1.0.0-integration",
   "private": true,
+  "type": "module",
   "description": "Playwright integration suite for claude-mac-chrome. Isolated from runtime. Excluded from release tarball per scripts/build-release.sh.",
   "scripts": {
     "test": "playwright test",


### PR DESCRIPTION
## Why

`tests/integration/playwright.config.ts` and `*.spec.ts` use `import.meta.url` via `fileURLToPath(import.meta.url)`. Without `"type": "module"` in `tests/integration/package.json`, Node parses these files as CommonJS and Playwright fails with:

```
SyntaxError: Cannot use 'import.meta' outside a module\nError: No tests found\n```\n\nReproduced on `main` runs 25543955285, 25485555242, 25424994960 (all `Playwright integration` workflow on macos-15).\n\n## What\n\nAdd `"type": "module"` to `tests/integration/package.json`.\n\n## Safety\n\nVerified zero CommonJS code in the suite:\n\n```\n$ grep -rn "module.exports\\|require(" tests/integration --include="*.ts" --include="*.mjs"\n(empty)\n```\n\nAll spec files already use ES module `import` syntax. The flip to ESM does not break any existing call sites.\n\n## Validation\n\nWill be validated by next nightly cron + on-demand `workflow_dispatch` of `Playwright integration` post-merge.