### PR TITLE
fix(blocklist): case-insensitive URL matching (closes #37)

### DIFF
--- a/skills/chrome-multi-profile/chrome-lib.sh
+++ b/skills/chrome-multi-profile/chrome-lib.sh
@@ -1213,8 +1213,17 @@ readonly -a CHROME_URL_BLOCKLIST=(
 # Check if a URL matches any blocklist pattern. Returns 0 (match/blocked),
 # 1 (clear). Uses `[[ == pattern ]]` which is consistent across bash 3.2
 # (macOS system bash) through 5.3 regardless of shell option state.
+#
+# Case-folds the URL to lowercase before matching — patterns are authored in
+# lowercase, and an attacker (or radamsa mutation) can otherwise bypass the
+# token check with mixed case (e.g. `cHeckout`, `PaYpAl.com`). T056 fuzz
+# regression #37 caught this: `cHeckout` evaded `*checkout*`. URL hostnames
+# are case-insensitive per RFC 3986 §3.2.2 and paths are conventionally
+# case-insensitive on the platforms we target. Tradeoff documented in
+# CHROME_URL_BLOCKLIST comment above.
 _chrome_check_url_blocklist() {
   local url="$1" pattern
+  url="$(printf '%s' "$url" | tr '[:upper:]' '[:lower:]')"
   for pattern in "${CHROME_URL_BLOCKLIST[@]}"; do
     # shellcheck disable=SC2053
     if [[ "$url" == $pattern ]]; then

--- a/tests/bats/01-url-blocklist.bats
+++ b/tests/bats/01-url-blocklist.bats
@@ -123,3 +123,42 @@ setup() {
 @test "blocklist: URL fragment on upgrade is blocked" {
   _chrome_check_url_blocklist "https://example.com/upgrade#plan-premium"
 }
+
+# ─── Case-folding regression — fuzz issue #37 ──────────────────────────
+# radamsa mutated `checkout` → `cHeckout`, which bypassed the substring
+# match because the comparison was case-sensitive. Patterns are authored
+# in lowercase; URLs MUST be lowercased before matching. RFC 3986 §3.2.2
+# makes hostnames case-insensitive, and paths are conventionally case-
+# insensitive on the platforms we target.
+
+@test "blocklist: mixed-case 'cHeckout' path is blocked (fuzz #37 regression)" {
+  _chrome_check_url_blocklist "https://www.paypal.com/cHeckout/review"
+}
+
+@test "blocklist: uppercase 'CHECKOUT' path is blocked" {
+  _chrome_check_url_blocklist "https://example.com/CHECKOUT/cart"
+}
+
+@test "blocklist: mixed-case 'UpGrAdE' path is blocked" {
+  _chrome_check_url_blocklist "https://account.proton.me/u/0/subscription/UpGrAdE"
+}
+
+@test "blocklist: mixed-case 'BiLLiNg' path is blocked" {
+  _chrome_check_url_blocklist "https://example.com/BiLLiNg/subscription"
+}
+
+@test "blocklist: mixed-case 'SuBsCrIbE' path is blocked" {
+  _chrome_check_url_blocklist "https://example.com/SuBsCrIbE/premium"
+}
+
+@test "blocklist: mixed-case 'CART' path is blocked" {
+  _chrome_check_url_blocklist "https://example.com/CART/123"
+}
+
+@test "blocklist: uppercase host 'CHECKOUT.STRIPE.COM' is blocked" {
+  _chrome_check_url_blocklist "https://CHECKOUT.STRIPE.COM/pay/cs_test"
+}
+
+@test "blocklist: mixed-case 'PaYpAl.com/CheckOut' is blocked" {
+  _chrome_check_url_blocklist "https://www.PaYpAl.com/CheckOut/review"
+}


### PR DESCRIPTION
## Summary
Fixes radamsa fuzz crash (#37) where case-mutated payment/upgrade URLs bypassed the blocklist.

## Root cause
`_chrome_check_url_blocklist` in `skills/chrome-multi-profile/chrome-lib.sh` used bash `[[ "$url" == $pattern ]]` glob matching, which is **case-sensitive**. Patterns like `*checkout*` did not match `CHECKOUT`, `cHeckout`, etc. Radamsa case-mutates seed URLs and trivially produced bypasses.

## Fix
Lowercase the URL via `tr '[:upper:]' '[:lower:]'` once before the pattern loop. Patterns are already lowercase. Minimal delta (+1 line of behavior).

## Justification
- RFC 3986 §3.2.2: hostnames are case-insensitive.
- Paths on the target SaaS (Stripe, PayPal, Proton, Google Pay, Amazon) are conventionally case-insensitive at the routing layer.
- The over-block tradeoff documented above `CHROME_URL_BLOCKLIST` already prefers false positives over missed payment intercepts.

## Tests
- Added 8 case-folding regressions in `tests/bats/01-url-blocklist.bats` covering hostname casing, path casing, and mixed casing across all sensitive pattern classes.
- All 34/34 bats tests pass locally.
- Original radamsa bypass mutation now correctly blocked.

## Files
- `skills/chrome-multi-profile/chrome-lib.sh` (+1)
- `tests/bats/01-url-blocklist.bats` (+39)

Closes #37