### PR TITLE
ci: dedup auto-issuer in parity-canary + fuzz workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,7 +38,7 @@ jobs:
         run: node tests/fuzz/html-grammar.mjs --iterations=10000
       - name: Fuzz Unicode confusables
         run: node tests/fuzz/unicode-confusables.mjs
-      - name: File issue on crash
+      - name: File or update issue on crash
         if: failure()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -46,12 +46,36 @@ jobs:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         with:
           script: |
+            // Dedup: find any open issue with the canonical title and append a
+            // run-link comment instead of opening another duplicate. 12+ open
+            // fuzz auto-issues demonstrate the runaway-dup defect this fixes.
             const runId = process.env.RUN_ID;
             const repoUrl = process.env.REPO_URL;
-            await github.rest.issues.create({
+            const title = '[fuzz] P1 — crash or envelope violation in nightly fuzz run';
+            const body = `Run: ${repoUrl}/actions/runs/${runId}\n\nSee logs for reproducer.`;
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[fuzz] P1 — crash or envelope violation in nightly fuzz run`,
-              body: `Run: ${repoUrl}/actions/runs/${runId}\n\nSee logs for reproducer.`,
-              labels: ['fuzz', 'p1', 'security']
+              state: 'open',
+              labels: 'fuzz,p1',
+              per_page: 100,
             });
+            const existing = open.find((i) => !i.pull_request && i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Recurrence: ${repoUrl}/actions/runs/${runId}`,
+              });
+              core.notice(`Recurrence appended to #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['fuzz', 'p1', 'security'],
+              });
+              core.notice(`Filed new issue #${created.data.number}`);
+            }

--- a/.github/workflows/parity-canary.yml
+++ b/.github/workflows/parity-canary.yml
@@ -31,7 +31,7 @@ jobs:
           npx playwright test --grep "parity" --reporter=json > /tmp/playwright.json
       - name: Diff envelopes
         run: node tests/js-fixtures/parity-diff.mjs /tmp/happy-dom.json /tmp/playwright.json
-      - name: File P1 on divergence
+      - name: File or update P1 on divergence
         if: failure()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -39,12 +39,36 @@ jobs:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         with:
           script: |
+            // Dedup: find any open issue with the canonical title and append a
+            // run-link comment instead of opening another duplicate. Issues
+            // #16/#23/#29/#38 demonstrate the runaway-dup defect this fixes.
             const runId = process.env.RUN_ID;
             const repoUrl = process.env.REPO_URL;
-            await github.rest.issues.create({
+            const title = '[parity-canary] P1 — happy-dom diverged from real Chromium';
+            const body = `Run: ${repoUrl}/actions/runs/${runId}\n\n**Action required:** Review HAPPY-DOM-FIDELITY.md. A stubbed API may need to be upgraded to integration-only.`;
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: '[parity-canary] P1 — happy-dom diverged from real Chromium',
-              body: `Run: ${repoUrl}/actions/runs/${runId}\n\n**Action required:** Review HAPPY-DOM-FIDELITY.md. A stubbed API may need to be upgraded to integration-only.`,
-              labels: ['parity', 'p1', 'security']
+              state: 'open',
+              labels: 'parity,p1',
+              per_page: 100,
             });
+            const existing = open.find((i) => !i.pull_request && i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Recurrence: ${repoUrl}/actions/runs/${runId}`,
+              });
+              core.notice(`Recurrence appended to #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['parity', 'p1', 'security'],
+              });
+              core.notice(`Filed new issue #${created.data.number}`);
+            }


### PR DESCRIPTION
## Summary

Both `parity-canary.yml` and `fuzz.yml` unconditionally called `issues.create` on failure, producing duplicate auto-issues every nightly run. Current state: **4+ open parity dupes** (#16/#23/#29/#38) and **12+ open fuzz dupes**.

## Fix

Replace each `issues.create` block with find-or-comment dedup logic:

1. `paginate(listForRepo, {state:'open', labels:'<class>,p1', per_page:100})`
2. `find(i => !i.pull_request && i.title === canonicalTitle)`
3. If found → `createComment` with run-link recurrence note
4. Else → `issues.create` as before

This stops the bleeding without masking real failures — recurrences become traceable comments on the canonical issue.

## Closes

- Closes #38

## Out of scope (separate root-cause PRs)

- **Parity:** missing `tests/js-fixtures/parity-diff.mjs` + `HAPPY-DOM-FIDELITY.md` cause unconditional parity-canary failure
- **Fuzz:** see #45 — `cflite_pr.yml` apt `radamsa` removal needs the build-from-source pattern already used in `fuzz.yml`
- **Cleanup:** the 16 stale dupe issues will be bulk-closed (keeping one canonical per defect class) after this merges

## Validation

- `actionlint` passes on both files
- Diff is symmetric — same 5-step pattern, only `labels` filter differs (`parity,p1` vs `fuzz,p1`) and canonical title text