### PR TITLE
ci(cflite): build radamsa from source

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,8 +1,18 @@
 FROM node:20-bookworm@sha256:8789e1e0752d81088a085689c04fdb7a5b16e8102e353118a4b049bbf05db8ac AS builder
 
+# radamsa is no longer available as a Debian/Ubuntu apt package on the
+# images used by ClusterFuzzLite (and apt-get install radamsa now fails
+# with "Unable to locate package" — see #45). Build radamsa from source
+# at the upstream pinned tag, mirroring the .github/workflows/fuzz.yml
+# pattern so the PR + cron Docker builds and the nightly host build use
+# the same radamsa version.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash jq radamsa \
-  && rm -rf /var/lib/apt/lists/*
+      bash jq git ca-certificates build-essential \
+  && git clone --depth 1 --branch v0.6 https://gitlab.com/akihe/radamsa.git /tmp/radamsa \
+  && make -C /tmp/radamsa \
+  && make -C /tmp/radamsa install \
+  && rm -rf /tmp/radamsa /var/lib/apt/lists/* \
+  && radamsa --version
 
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
Closes #45.

## Root cause
`.clusterfuzzlite/Dockerfile` installed `radamsa` via apt:
```
RUN apt-get update && apt-get install -y --no-install-recommends \
    bash jq radamsa
```

The `radamsa` package is no longer available on the Debian bookworm /
Ubuntu pockets enabled in the ClusterFuzzLite builder image, so every
`pr-fuzzing` run now fails in the docker-build phase with `E: Unable
to locate package radamsa` (e.g. PR #44 run 25573532340).

## Fix
Mirror the source-build pattern already used by `.github/workflows/fuzz.yml`:
clone `gitlab.com/akihe/radamsa` at the pinned `v0.6` tag, `make && make
install`, then strip caches and the build toolchain leftovers. Both
`cflite_pr.yml` and `cflite_cron.yml` consume the same Dockerfile, so
the cron job is fixed by the same change with no workflow-YAML edits.

No `permissions:` changes needed — `cflite_pr.yml` and `cflite_cron.yml`
already have workflow-root + per-job least-privilege blocks.

## Acceptance (issue #45)
- [x] `pr-fuzzing` Docker build no longer hits the apt error
- [x] No regression on scheduled `cflite_cron.yml` (shared Dockerfile)
- [x] `radamsa --version` runs at end of Dockerfile RUN to fail-fast on bad source builds