### PR TITLE
ci(cflite): wire build.sh as /usr/local/bin/compile

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -26,3 +26,9 @@ RUN mkdir -p /out && \
     chmod +x /out/fuzz_html_grammar && \
     printf '#!/usr/bin/env bash\nexec node /src/tests/fuzz/unicode-confusables.mjs\n' > /out/fuzz_unicode_confusables && \
     chmod +x /out/fuzz_unicode_confusables
+
+# ClusterFuzzLite's OSS-Fuzz-derived contract requires a `compile`
+# executable on $PATH inside the container. Wire build.sh in as that
+# entry point so `Build fuzzers` finds it (#48).
+COPY .clusterfuzzlite/build.sh /usr/local/bin/compile
+RUN chmod +x /usr/local/bin/compile


### PR DESCRIPTION
## Summary

ClusterFuzzLite's OSS-Fuzz-derived contract requires a `compile` executable on `$PATH` inside the container. The repo's existing `.clusterfuzzlite/build.sh` was never wired in, so `Build fuzzers` exits with `compile: command not found` on every PR run after #47 unblocked the radamsa apt regression.

This PR appends two lines to `.clusterfuzzlite/Dockerfile` that copy `build.sh` to `/usr/local/bin/compile` and `chmod +x` it. No base-image swap — that's Option 2 in #48 and out of scope.

`build.sh` is a thin compile shim that copies pre-built fuzz targets from `/out/` (where the Dockerfile stages them) to `$OUT` — exactly the OSS-Fuzz contract for shell/node fuzz wrappers.

Closes #48.

## Test plan

- [x] `.clusterfuzzlite/build.sh` confirmed to be a real OSS-Fuzz compile shim
- [x] `cflite_pr.yml` and `cflite_cron.yml` both reference the same Dockerfile (PR #47)
- [ ] CI: `pr-fuzzing / Build fuzzers` no longer errors with `compile: command not found`
- [ ] CI: `pr-fuzzing / Run fuzzers` reaches its own logic (continue-on-error remains)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>