### PR TITLE
ci(cflite): generate fuzz wrappers in build.sh after volume mount

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -17,18 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . /src
 WORKDIR /src
 
-# ClusterFuzzLite expects fuzz targets as executables in /out/.
-# Our fuzzers are shell + node scripts — wrap them as executable entry points.
-RUN mkdir -p /out && \
-    cp tests/fuzz/radamsa-urls.sh /out/fuzz_radamsa_urls && \
-    chmod +x /out/fuzz_radamsa_urls && \
-    printf '#!/usr/bin/env bash\nexec node /src/tests/fuzz/html-grammar.mjs --iterations="${1:-1000}"\n' > /out/fuzz_html_grammar && \
-    chmod +x /out/fuzz_html_grammar && \
-    printf '#!/usr/bin/env bash\nexec node /src/tests/fuzz/unicode-confusables.mjs\n' > /out/fuzz_unicode_confusables && \
-    chmod +x /out/fuzz_unicode_confusables
-
 # ClusterFuzzLite's OSS-Fuzz-derived contract requires a `compile`
 # executable on $PATH inside the container. Wire build.sh in as that
-# entry point so `Build fuzzers` finds it (#48).
+# entry point so `Build fuzzers` finds it (#48). build.sh generates
+# the fuzz_* wrappers into $OUT at compile time — pre-staging them
+# here under /out is pointless because CFL invokes the build container
+# with `--volumes-from <helper>` against a helper that declares /out
+# as a volume, which shadows any image-baked /out content with an
+# empty volume mount (#50).
 COPY .clusterfuzzlite/build.sh /usr/local/bin/compile
 RUN chmod +x /usr/local/bin/compile

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 # ClusterFuzzLite build script. Generates fuzz target wrappers into $OUT.
 #
 # Our fuzzers are shell + node scripts, not compiled libFuzzer binaries,
@@ -6,11 +6,17 @@
 # CFL's fuzzing harness can invoke.
 #
 # IMPORTANT: this generation must happen here, not in the Dockerfile.
-# CFL invokes the build container with `--volumes-from <helper>` against
-# a helper that declares /out as a volume; that mount shadows any
-# /out/fuzz_* files baked into the image, so pre-staging them in the
-# Dockerfile silently no-ops at runtime (#50). build.sh runs AFTER the
-# volume mount, so wrappers written into $OUT here actually persist.
+# CFL invokes the build container with `--volumes-from <helper>` and an
+# `OUT=...` env that points at a host-bind path the helper provides;
+# any /out/fuzz_* files baked into the image are unreachable at runtime
+# (either shadowed by the helper's /out volume or simply written into
+# the wrong dir relative to $OUT). build.sh runs AFTER the volume
+# mount with the correct $OUT in scope, so wrappers written here
+# actually persist (#50).
+
+# Belt-and-suspenders: $OUT is provided by CFL but the directory
+# itself may not pre-exist inside the build container.
+mkdir -p "$OUT"
 
 # Wrapper 1: radamsa-driven URL fuzzer (existing shell script).
 cp /src/tests/fuzz/radamsa-urls.sh "$OUT/fuzz_radamsa_urls"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,7 +1,31 @@
 #!/bin/bash -eu
-# ClusterFuzzLite build script. Copies fuzz targets to $OUT.
-# Our targets are shell/node wrappers, not compiled libFuzzer binaries.
-# The Dockerfile handles the actual build; this script satisfies the
-# ClusterFuzzLite contract of having a build.sh present.
+# ClusterFuzzLite build script. Generates fuzz target wrappers into $OUT.
+#
+# Our fuzzers are shell + node scripts, not compiled libFuzzer binaries,
+# so "compile" here means: emit thin executable wrappers in $OUT/ that
+# CFL's fuzzing harness can invoke.
+#
+# IMPORTANT: this generation must happen here, not in the Dockerfile.
+# CFL invokes the build container with `--volumes-from <helper>` against
+# a helper that declares /out as a volume; that mount shadows any
+# /out/fuzz_* files baked into the image, so pre-staging them in the
+# Dockerfile silently no-ops at runtime (#50). build.sh runs AFTER the
+# volume mount, so wrappers written into $OUT here actually persist.
 
-cp /out/fuzz_* "$OUT/" 2>/dev/null || true
+# Wrapper 1: radamsa-driven URL fuzzer (existing shell script).
+cp /src/tests/fuzz/radamsa-urls.sh "$OUT/fuzz_radamsa_urls"
+chmod +x "$OUT/fuzz_radamsa_urls"
+
+# Wrapper 2: HTML grammar fuzzer (node).
+cat > "$OUT/fuzz_html_grammar" <<'EOF'
+#!/usr/bin/env bash
+exec node /src/tests/fuzz/html-grammar.mjs --iterations="${1:-1000}"
+EOF
+chmod +x "$OUT/fuzz_html_grammar"
+
+# Wrapper 3: Unicode confusables fuzzer (node).
+cat > "$OUT/fuzz_unicode_confusables" <<'EOF'
+#!/usr/bin/env bash
+exec node /src/tests/fuzz/unicode-confusables.mjs
+EOF
+chmod +x "$OUT/fuzz_unicode_confusables"


### PR DESCRIPTION
Closes #50.

## Problem

ClusterFuzzLite invokes the build container with `--volumes-from
<helper>` against a helper that declares `/out` as a volume. That mount
shadows any image-baked `/out/fuzz_*` files with an empty volume, so
the Dockerfile's pre-staged wrappers vanish at runtime and CFL reports
`No fuzz targets found in out dir`.

The previous `build.sh` also had `cp /out/fuzz_* "\$OUT/" 2>/dev/null || true`,
which silently swallowed the failure — that suppression is what hid this
for months across PRs #47 and #49.

## Fix (Option 3 from #50)

Move all wrapper generation into `.clusterfuzzlite/build.sh`, which runs
AFTER the volume mount, so the wrappers land directly in `\$OUT` where
CFL actually looks.

Specifically:

- **Dockerfile**: drop the `RUN mkdir -p /out && cp ... && printf ...`
  block that pre-staged the three `fuzz_*` wrappers under `/out`. Keep
  the radamsa source build (PR #47) and the `compile` symlink wiring
  (PR #49) — neither is affected by the `/out` shadow.
- **build.sh**: generate the three wrappers directly into `\$OUT` with
  explicit `cat <<EOF` heredocs and `chmod +x`, and drop the silent
  `2>/dev/null || true` so any future failure surfaces loudly.

## Verification

Simulated the CFL flow locally against the rebuilt image:

```bash
HELPER=\$(docker create -v /out cmc-cflite-50:test /bin/true)
docker run --rm --volumes-from "\$HELPER" -e OUT=/out cmc-cflite-50:test \\
  bash -c '/usr/local/bin/compile && ls -l /out/'
```

All three wrappers appear as executables in `/out/`:

```
-rwxr-xr-x  fuzz_html_grammar
-rwxr-xr-x  fuzz_radamsa_urls
-rwxr-xr-x  fuzz_unicode_confusables
```

Functionally identical to the previous Dockerfile-baked wrappers.

## Cron parity

Both `cflite_pr.yml` and `cflite_cron.yml` call into the same
`google/clusterfuzzlite/actions/build_fuzzers` action against the same
Dockerfile, so this fix applies identically to both. The cron path is
not regressed.

## Acceptance

`pr-fuzzing` Build fuzzers should now succeed AND Run fuzzers should
actually execute (instead of being skipped due to the build failure).