### PR TITLE
ci(cflite): keep unaffected fuzz targets on PR builds

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -23,6 +23,13 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: javascript
+          # Our three fuzz targets are thin wrappers generated at compile
+          # time from build.sh; they do not sit one-to-one against a
+          # source file CFL's affected-detection can match. Without this
+          # flag `mode: code-change` deletes ALL targets on any PR that
+          # does not touch tests/fuzz/**, which permanently breaks the
+          # build with "No fuzz targets found in out dir" (#50).
+          keep-unaffected-fuzz-targets: true
       - name: Run fuzzers
         id: run
         if: steps.build.outcome == 'success'


### PR DESCRIPTION
Follow-up to #51. After the /out volume-shadow fix landed, the
`pr-fuzzing` Build fuzzers step now correctly emits all three
wrappers into `\$OUT`, but CFL's affected-only filter (gated by
`mode: code-change` + default `keep-unaffected-fuzz-targets: false`)
deletes them all on any PR that doesn't touch `tests/fuzz/**`.

Concretely, the CI log on #51 shows compile succeeds:

```
+ mkdir -p /github/workspace/build-out
+ cp /src/tests/fuzz/radamsa-urls.sh /github/workspace/build-out/fuzz_radamsa_urls
+ chmod +x /github/workspace/build-out/fuzz_radamsa_urls
+ cat
+ chmod +x /github/workspace/build-out/fuzz_html_grammar
+ cat
+ chmod +x /github/workspace/build-out/fuzz_unicode_confusables
INFO - Removing unaffected fuzz targets.
INFO - Files changed in PR: ['.clusterfuzzlite/Dockerfile', '.clusterfuzzlite/build.sh']
ERROR - No fuzz targets found in out dir.
```

Our fuzzers are wrapper shims emitted by `build.sh`, not 1:1
source artifacts that map cleanly to changed files. Setting
`keep-unaffected-fuzz-targets: true` makes CFL skip the
affected-only filter and exercise every target on every PR,
which is what we want for a 3-target hygiene pipeline.

Cron is unaffected (`mode: batch` never runs the filter).