### PR TITLE
docs(readme): add services footer — spec 020 FR-006

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,9 @@ The insight that Chrome's own `Local State` file can serve as an authoritative p
 - [yolo-labz/kokoro-speakd](https://github.com/yolo-labz/kokoro-speakd) — TTS daemon for spoken status feedback during long browser-automation runs.
 - Architecture deep-dives on multi-profile detection + cliclick + isTrusted bypass: [blog.home301server.com.br](https://blog.home301server.com.br).
 - Author portfolio: [portfolio.home301server.com.br](https://portfolio.home301server.com.br).
+
+---
+
+## Services
+
+Compliance-grade AI architecture for regulated workloads — async-first, USD-denominated, LATAM-based / EN-fluent. See [blog.home301server.com.br/services](https://blog.home301server.com.br/services/).


### PR DESCRIPTION
## Summary

Adds capability-led services footer to README per spec 020 FR-006 (yolo-labz README footer rollout, task T-031).

Links to [blog.home301server.com.br/services](https://blog.home301server.com.br/services/) — Compliance-Grade AI Architect landing page shipped in Notes#60 + blog#78.

## Stealth posture

- Capability-led framing: "Compliance-grade AI architecture for regulated workloads"
- NO availability language ("open to work", "available for hire", "next role")
- NO autobiographical retrospective
- Single sentence + link

## Test plan

- [x] Footer present at end of README
- [x] Single sentence, single link, no PR-bait
- [x] Stealth-lint compliant (idempotent vs all forbidden terms)
- [ ] CI green
- [ ] **Pedro `OK merge` required** (per-message canon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)