### PR TITLE
fix(parity-canary): pin Homebrew bash 5 (closes #5)

### DIFF
--- a/.github/workflows/parity-canary.yml
+++ b/.github/workflows/parity-canary.yml
@@ -21,6 +21,16 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20.18.1"
+      - name: Ensure bash 4+ available (macOS /bin/bash is 3.2)
+        run: |
+          if [ ! -x /opt/homebrew/bin/bash ] && [ ! -x /usr/local/bin/bash ]; then
+            brew install bash
+          fi
+          if [ -x /opt/homebrew/bin/bash ]; then
+            echo "BASH_BIN=/opt/homebrew/bin/bash" >> "$GITHUB_ENV"
+          else
+            echo "BASH_BIN=/usr/local/bin/bash" >> "$GITHUB_ENV"
+          fi
       - name: Run happy-dom harness
         run: node tests/js-fixtures/run.mjs > /tmp/happy-dom.json
       - name: Run Playwright on same fixtures

--- a/tests/js-fixtures/run.mjs
+++ b/tests/js-fixtures/run.mjs
@@ -66,10 +66,24 @@ const BLOCKED_REASONS = new Set([
 
 // --- Extract safety JS from chrome-lib.sh ------------------------------
 
+// chrome-lib.sh uses `local -A` and `mapfile`, which require bash 4.0+.
+// macOS ships /bin/bash 3.2.57, so prefer a Homebrew-installed bash when
+// available. Honors $BASH_BIN for explicit override (e.g. from CI workflow).
+function resolveBashBin() {
+  if (process.env.BASH_BIN && existsSync(process.env.BASH_BIN)) {
+    return process.env.BASH_BIN;
+  }
+  for (const candidate of ["/opt/homebrew/bin/bash", "/usr/local/bin/bash"]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return "bash";
+}
+const BASH_BIN = resolveBashBin();
+
 function emitSafetyJs(selector, _lexicon) {
   // _emit_safety_js is a CLI dispatch verb in chrome-lib.sh main().
   // Invoke via bash: `bash chrome-lib.sh _emit_safety_js <selector>`.
-  const res = spawnSync("bash", [LIB, "_emit_safety_js", selector]);
+  const res = spawnSync(BASH_BIN, [LIB, "_emit_safety_js", selector]);
   if (res.status !== 0) {
     throw new Error(`_emit_safety_js failed: ${res.stderr.toString()}`);
   }


### PR DESCRIPTION
## Summary

- `chrome-lib.sh` uses `local -A` + `mapfile` (bash 4+); macOS ships `/bin/bash` 3.2.57.
- Weekly parity-canary therefore fails at `_emit_safety_js` invocation, masking actual happy-dom divergence with a config error.
- `run.mjs` now prefers `/opt/homebrew/bin/bash` → `/usr/local/bin/bash` → PATH. `$BASH_BIN` env var overrides.
- `parity-canary.yml` installs bash 5 (no-op on current macos-15 images) and pins `BASH_BIN`.

Closes #5.

## Test plan

- [ ] CI green on this PR
- [ ] Manually trigger Parity canary workflow against this branch (`gh workflow run "Parity canary" --ref 59-bash5-canary`)
- [ ] Verify run reaches Diff envelopes step instead of dying at `_emit_safety_js`