### PR TITLE
ci(integration): install modern bash — chrome-lib requires 4.0+

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,14 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20.18.1"
+      # chrome-lib.sh hard-requires Bash 4.0+ and macOS ships 3.2 (frozen since
+      # 2007); the suite spawns `bash` from PATH, so install brew's bash, which
+      # /opt/homebrew/bin puts ahead of /bin/bash. This is the lib's own
+      # documented remedy and the reason this job has been red since 2026-05-30.
+      - name: Install modern Bash
+        run: |
+          brew install bash
+          bash --version | head -1
       - name: Install Playwright deps
         working-directory: tests/integration
         run: |


### PR DESCRIPTION
Root cause of the red nightly (issue #68): the Playwright suite spawns `chrome-lib.sh` via `bash` from PATH; macos-15 resolves `/bin/bash` 3.2.57 and the lib's own version gate aborts every test (`[chrome-lib] error: Bash 4.0+ required`). The lib's documented remedy is `brew install bash` — this adds exactly that step, so `/opt/homebrew/bin/bash` 5.x wins PATH resolution.

Not a WAF/Cloudflare issue (the earlier #68 hypothesis) — pure runner-bash mismatch. Verified by dispatching the workflow after merge. Closes #68.