### PR TITLE
test(integration): JSON.parse the safety envelope in 4 specs

### DIFF
--- a/tests/integration/clickjack.spec.ts
+++ b/tests/integration/clickjack.spec.ts
@@ -28,7 +28,9 @@ function emitSafetyJs(selector: string): string {
 async function runSafetyCheck(page: any, selector: string): Promise<any> {
   const content = emitSafetyJs(selector);
   await page.addScriptTag({ content });
-  const envelope = await page.evaluate(() => (window as any).__cmc_envelope);
+  const envelope = JSON.parse(
+    await page.evaluate(() => (window as any).__cmc_envelope),
+  );
   return typeof envelope === "string" ? JSON.parse(envelope) : envelope;
 }
 

--- a/tests/integration/dialog-inert.spec.ts
+++ b/tests/integration/dialog-inert.spec.ts
@@ -26,7 +26,9 @@ test("dialog: button inside dialog without open attr is inert-blocked", async ({
 }) => {
   await page.goto("/06-inert-ancestor.html");
   await page.addScriptTag({ content: emitSafetyJs("#target") });
-  const envelope = await page.evaluate(() => (window as any).__cmc_envelope);
+  const envelope = JSON.parse(
+    await page.evaluate(() => (window as any).__cmc_envelope),
+  );
   expect(envelope.element_found).toBe(true);
   expect(envelope.ok).toBe(false);
   expect(envelope.blocked_reason).toBe("inert_container");

--- a/tests/integration/pseudo-element.spec.ts
+++ b/tests/integration/pseudo-element.spec.ts
@@ -26,7 +26,9 @@ test("pseudo: ::before content 'Subscribe' caught via getComputedStyle", async (
 }) => {
   await page.goto("/05-pseudo-before-content.html");
   await page.addScriptTag({ content: emitSafetyJs("#target") });
-  const envelope = await page.evaluate(() => (window as any).__cmc_envelope);
+  const envelope = JSON.parse(
+    await page.evaluate(() => (window as any).__cmc_envelope),
+  );
   expect(envelope.element_found).toBe(true);
   expect(envelope.ok).toBe(false);
   expect(envelope.blocked_reason).toMatch(/^purchase_button_text_depth_/);

--- a/tests/integration/visibility.spec.ts
+++ b/tests/integration/visibility.spec.ts
@@ -19,7 +19,7 @@ function emitSafetyJs(selector: string): string {
 
 async function runSafetyCheck(page: any, selector: string): Promise<any> {
   await page.addScriptTag({ content: emitSafetyJs(selector) });
-  return page.evaluate(() => (window as any).__cmc_envelope);
+  return JSON.parse(await page.evaluate(() => (window as any).__cmc_envelope));
 }
 
 test("visibility: zero-dimensions button blocked", async ({ page }) => {


### PR DESCRIPTION
Second half of the #68 fix. With bash 4 in place (#72), the suite finally RAN — and exposed that 4 of 5 specs assert object fields directly on `__cmc_envelope`, which is a JSON **string** (the lib returns `JSON.stringify(result)` because the production path consumes it via AppleScript → jq). `positive-dispatch.spec.ts` already parses it; this aligns `dialog-inert`, `pseudo-element`, `clickjack`, `visibility` to the same pattern. The lib is unchanged — its string contract is the production contract.

Local validation on NixOS is blocked by the documented libnspr4 chromium chain; verifying on the macOS runner via workflow dispatch after merge.