### PR TITLE
fix(safety): skip script/style source in purchase-lexicon walk

### DIFF
--- a/skills/chrome-multi-profile/chrome-lib.sh
+++ b/skills/chrome-multi-profile/chrome-lib.sh
@@ -1734,10 +1734,32 @@ _chrome_safety_check_js() {
 
     // Gather text from: textContent UNION innerText UNION shadow DOM UNION ::before/::after
     // NFR-SR-V2-7, NFR-SR-V2-8, NFR-SR-V2-9.
+    // textContent is collected via a TreeWalker that skips script/style/
+    // noscript/template subtrees: raw textContent at <body>/<html> depth
+    // swallows inline <script> source, and ubiquitous strings like
+    // "checkout" inside page JS would false-positive the lexicon. Hidden
+    // text (display:none labels) still counts — only code/style text is out.
+    function _visibleishText(root) {
+      try {
+        const SKIP = { SCRIPT: 1, STYLE: 1, NOSCRIPT: 1, TEMPLATE: 1 };
+        const out = [];
+        (function walk(n, d) {
+          if (!n || d > 40 || out.length > 2000) return;
+          if (n.nodeType === 3) { out.push(n.nodeValue || ""); return; }
+          const tag = n.tagName ? String(n.tagName).toUpperCase() : "";
+          if (SKIP[tag]) return;
+          const kids = n.childNodes || [];
+          for (let i = 0; i < kids.length; i++) walk(kids[i], d + 1);
+        })(root, 0);
+        return out.join(" ");
+      } catch (_) {
+        try { return root.textContent || ""; } catch (_) { return ""; }
+      }
+    }
     function gatherAllText(node, depth) {
       if (!node || depth > 10) return "";
       let parts = [];
-      try { parts.push(node.textContent || ""); } catch(_) {}
+      try { parts.push(_visibleishText(node)); } catch(_) {}
       try { parts.push(node.innerText || ""); } catch(_) {}
       // CSS pseudo-element content
       try {

--- a/tests/fixtures/04-shadow-dom-open.expected.json
+++ b/tests/fixtures/04-shadow-dom-open.expected.json
@@ -10,5 +10,6 @@
   "fired_rail_trace": ["element_lookup", "ancestor_text_walk"],
   "selector": "#host",
   "variant_group": "purchase_button_text",
-  "note": "Observed behavior: happy-dom's shadow-root textContent aggregation surfaces 'Upgrade' via the parent body at depth 1, not the host itself at depth 0. The rail still fires — the point is defense-in-depth, not the exact depth."
+  "harness_requirement": "integration_only",
+  "note": "The shadow root is built by an inline <script>. The happy-dom harness sets documentElement.innerHTML, which per the HTML spec does not execute scripts, so the shadow DOM never exists there and gatherAllText has nothing to descend into. (The pre-2026-06 happy-dom 'pass' was a false positive: the lexicon matched the SOURCE text of that inline script, not real shadow content — see chrome-lib.sh _visibleishText.) Now Chromium-authoritative, verified by tests/integration/shadow-dom.spec.ts, which asserts the purchase_button_text family rather than a fixed depth."
 }

--- a/tests/fixtures/14-nested-shadow-root.expected.json
+++ b/tests/fixtures/14-nested-shadow-root.expected.json
@@ -10,5 +10,6 @@
   "fired_rail_trace": ["element_lookup", "ancestor_text_walk"],
   "selector": "#outer-host",
   "variant_group": "purchase_button_text",
-  "note": "Nested shadow root text surfaces via parent body at depth 1, same observed behavior pattern as fixture 04."
+  "harness_requirement": "integration_only",
+  "note": "Two nested shadow roots built by an inline <script>. The happy-dom harness does not execute scripts (innerHTML assignment), so neither shadow root exists there. Same situation as fixture 04: the old happy-dom 'pass' matched inline-script source text, not real shadow content. Now Chromium-authoritative, verified by tests/integration/shadow-dom.spec.ts (asserts the purchase_button_text family, not a fixed depth)."
 }

--- a/tests/goldens.lock
+++ b/tests/goldens.lock
@@ -4,5 +4,5 @@
 #
 # Regenerate with: scripts/regenerate-goldens.sh
 
-safety_js_sha256=31d87b1dd729d0e93260bf08b8ef503d500aaed9d18c83a3084ebb236cf0ccd9
+safety_js_sha256=47e4bd73bd34f83529cb395ce851418d78f12f2eee2400e1ee91fc200ec5fb19
 safety_js_selector_stub=#target

--- a/tests/integration/shadow-dom.spec.ts
+++ b/tests/integration/shadow-dom.spec.ts
@@ -1,0 +1,50 @@
+// Feature 006 — shadow-DOM integration test.
+// Per spec §NFR-SR-V2-7 (gatherAllText must descend open shadow roots).
+//
+// These fixtures build their shadow DOM from an inline <script>. The
+// happy-dom JS-fixture harness sets documentElement.innerHTML, which per the
+// HTML spec does not execute scripts, so it can never materialize the shadow
+// tree — the fixtures are marked `harness_requirement: integration_only` and
+// are authoritative ONLY here, under real Chromium.
+//
+// We assert the purchase_button_text *family* fires rather than a fixed depth:
+// the exact ancestor depth at which the token surfaces is a Chromium DOM
+// detail, and the rail's contract is "the purchase lexicon was found in the
+// shadow subtree", not a specific depth.
+
+import { test, expect } from "@playwright/test";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const LIB = join(REPO_ROOT, "skills", "chrome-multi-profile", "chrome-lib.sh");
+
+function emitSafetyJs(selector: string): string {
+  const raw = execFileSync("bash", [LIB, "_emit_safety_js", selector], {
+    encoding: "utf8",
+  });
+  return `window.__cmc_envelope = ${raw.trim()};`;
+}
+
+async function runSafetyCheck(page: any, selector: string): Promise<any> {
+  await page.addScriptTag({ content: emitSafetyJs(selector) });
+  return JSON.parse(await page.evaluate(() => (window as any).__cmc_envelope));
+}
+
+test("shadow-dom: open shadow root purchase token blocked", async ({ page }) => {
+  await page.goto("/04-shadow-dom-open.html");
+  const envelope = await runSafetyCheck(page, "#host");
+  expect(envelope.element_found).toBe(true);
+  expect(envelope.ok).toBe(false);
+  expect(envelope.blocked_reason).toMatch(/^purchase_button_text_depth_\d$/);
+});
+
+test("shadow-dom: nested shadow roots purchase token blocked", async ({ page }) => {
+  await page.goto("/14-nested-shadow-root.html");
+  const envelope = await runSafetyCheck(page, "#outer-host");
+  expect(envelope.element_found).toBe(true);
+  expect(envelope.ok).toBe(false);
+  expect(envelope.blocked_reason).toMatch(/^purchase_button_text_depth_\d$/);
+});


### PR DESCRIPTION
## What

`gatherAllText` (the purchase-button safety rail) collected raw `textContent` at `<body>`/`<html>` depth, which includes inline `<script>` source. The Playwright integration suite injects the safety check via `page.addScriptTag`, so **that script's own source** — which embeds the lexicon and reason strings (`purchase`, `pay`, …) — leaked into the ancestor text walk and falsely fired `purchase_button_text_depth_2` on benign buttons.

This is the never-green integration failure tracked in #68: `visibility.spec` `08-zero-dimensions` and `09-hidden-visibility` (both clean DOMs, button text "Mark as read") received `purchase_button_text_depth_2` instead of `zero_dimensions` / `not_visible`.

It is also a **real-world false positive**: any page with inline analytics or checkout JS (`gtag('event','purchase')`, etc.) would trip the lexicon the same way.

## Fix

Replace the raw `textContent` push with `_visibleishText`, a recursive walk that skips `SCRIPT` / `STYLE` / `NOSCRIPT` / `TEMPLATE` subtrees. Rendered text **and** hidden (`display:none`) element text still count — only code/style source is excluded. The shadow-DOM descent and `::before`/`::after` gathering are unchanged.

## Fixtures 04 / 14 (shadow DOM)

These build their shadow tree from an inline `<script>`. The happy-dom JS-fixture harness sets `documentElement.innerHTML`, which per the HTML spec does **not** execute scripts — so it never materialized the shadow tree. Their previous happy-dom "pass" was *this very false positive*: the lexicon matched the inline-script **source** (`btn.textContent = "Upgrade"`), not real shadow content.

- Marked `harness_requirement: integration_only` (happy-dom skips them, like `07-clickjack`).
- Added `tests/integration/shadow-dom.spec.ts` to verify real open-shadow-root descent under Chromium. It asserts the `purchase_button_text` **family** fires (the exact ancestor depth is a Chromium DOM detail), restoring coverage the happy-dom sham never actually provided.

## Verification

- `bash tests/run.sh` → **13 passed, 0 failed, 3 skipped** (04/07/14 integration-only); bats + meta-tests green.
- `goldens.lock` regenerated for the new emitted JS.
- Integration suite (`integration.yml`) is cron/tag/dispatch-only and never runs on PRs, so it will be dispatched against `main` after merge to confirm `visibility.spec` 08/09 are green and the new `shadow-dom.spec` passes.

Closes #68 (in substance — supersedes the premature auto-close by #73, which fixed only the envelope-parse layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)