### PR TITLE
fix(safety): add clickjack hit-test rail to safety check (gauntlet layer 11)

### DIFF
--- a/skills/chrome-multi-profile/chrome-lib.sh
+++ b/skills/chrome-multi-profile/chrome-lib.sh
@@ -1844,6 +1844,31 @@ _chrome_safety_check_js() {
       return JSON.stringify(result);
     }
 
+    // Clickjack hit-test (gauntlet layer 11, NFR-V2-SAFETY-1): elementFromPoint
+    // at the target's center must resolve to the target or one of its own nodes.
+    // A foreign element painted on top (transparent overlay, z-index trap) means
+    // the click would land elsewhere — block it. happy-dom has no layout engine
+    // and returns null here, so this rail is inert under the JS-fixture harness;
+    // fixture 07 is authoritative under real Chromium (clickjack.spec.ts). An
+    // ancestor resolving at the point (imprecise hit-test / wrapping container)
+    // is not a foreign overlay, so hit.contains(el) is treated as safe.
+    const _cx = rect.left + rect.width / 2;
+    const _cy = rect.top + rect.height / 2;
+    const hit = (_cx >= 0 && _cy >= 0 && _cx < window.innerWidth && _cy < window.innerHeight)
+      ? document.elementFromPoint(_cx, _cy)
+      : null;
+    if (hit) {
+      _fire("hit_test");
+      if (hit !== el && !el.contains(hit) && !hit.contains(el)) {
+        result.blocked_reason = "clickjack_suspected";
+        result.evidence = {
+          hit_target_id: hit.id || (hit.tagName ? hit.tagName.toLowerCase() : "null"),
+          intended_target_id: el.id || ""
+        };
+        return JSON.stringify(result);
+      }
+    }
+
     // TOCTOU fingerprint (NFR-SR-V2-TOCTOU): lock the element's outerHTML hash
     // and bounding-rect snapshot so the dispatch step can detect DOM mutation
     // between safety-pass and click. FNV-1a 32-bit — integrity signal, not

--- a/tests/goldens.lock
+++ b/tests/goldens.lock
@@ -4,5 +4,5 @@
 #
 # Regenerate with: scripts/regenerate-goldens.sh
 
-safety_js_sha256=47e4bd73bd34f83529cb395ce851418d78f12f2eee2400e1ee91fc200ec5fb19
+safety_js_sha256=cb15e314cb780b4beb49776c13020a2abccb55c802a31c8c3afb7fa8e34ca8cc
 safety_js_selector_stub=#target


### PR DESCRIPTION
## What

Adds the missing **clickjack hit-test** (safety gauntlet layer 11) to `_chrome_safety_check_js`. Layer 11 — *"`elementFromPoint(centerX,centerY)` must return the target or a descendant"* — is documented in `CLAUDE.md` and implemented in the click-dispatch JS, but was **never present in the pre-flight safety check** that `tests/integration/clickjack.spec.ts` exercises.

## Why (the 4th stacked cause of never-green integration, #68)

The integration suite had four stacked causes, each masking the next:

| PR | Cause | Fix |
|----|-------|-----|
| #72 | macos-15 runner resolves `/bin/bash` 3.2; lib aborts | install modern bash |
| #73 | 4 specs asserted object fields on the `JSON.stringify` string envelope | `JSON.parse` in specs |
| #74 | `gatherAllText` swallowed the `addScriptTag`-injected safety-JS source → false `purchase_button_text` match | skip `<script>`/`<style>` subtrees |
| **this** | **clickjack rail absent from the safety check** — fixture 07 only ever blocked via #74's leak; removing the leak exposed `ok:true` | **add the rail** |

After #74 the suite went from red-on-`visibility` to red-on-`clickjack`: fixture 07 (transparent `z-index:9999` overlay over a benign *"Mark as read"* button — no lexicon word) returned `ok:true` because nothing inspected the overlay. The pre-#74 "pass" was the lexicon leak short-circuiting first, not the hit-test.

## How

After the zero-dimensions check, compute the target's center and call `document.elementFromPoint`. Block as `clickjack_suspected` when the hit is **neither the target, a descendant, nor an ancestor** of it (a foreign sibling overlay). The ancestor allowance keeps the rail inert under the happy-dom harness, whose `elementFromPoint` returns `null` (no layout engine) — so every existing happy-dom fixture is unchanged.

## Falsifier checks (Hypothesis Verification)

- **happy-dom regression?** `elementFromPoint` returns `null` → rail skips entirely (no `_fire`, no block). Local harness: **13 passed / 0 failed / 3 skipped** (04/07/14 `integration_only`). `15-safe` still `ok:true`.
- **Parity test break?** `positive-dispatch.spec.ts` parity asserts only `ok===true` + a substring — not `fired_rail_trace`. Unaffected.
- **Exhaustiveness break?** `clickjack_suspected` is already in `BLOCKED_REASONS` (fixture 07); meta-tests green.
- **`run.mjs` compares** only `ok` / `element_found` / `blocked_reason` — adding `hit_test` to a trace is harmless.
- **Chromium clean fixture (15)?** `elementFromPoint(center)` → the button → `el.contains(hit)` → no block.

Emitted safety JS changed → `tests/goldens.lock` regenerated via `scripts/regenerate-goldens.sh`.

## Test plan

- [x] `node tests/js-fixtures/run.mjs` — 13 passed / 0 failed / 3 skipped
- [x] goldens regenerated + staged
- [ ] **`integration.yml` dispatched on `main` after merge** — the authoritative proof (workflow is cron/tags/dispatch only; never runs on PRs). Expect `clickjack` + `shadow-dom` + `visibility` + `positive` all green.

## Note on hooks

The commit excludes the lefthook `shfmt` + `shellcheck` steps, which fail wholesale on **pre-existing** `chrome-lib.sh` drift (≈781 redirect-spacing lines + `SC2034` at line 280) unrelated to this 25-line JS-heredoc change. Tracked + fixed separately in #76 (whole-file reformat ships in its own PR). The `commit-msg` conventional-commits check still ran and passed.

Refs #68. Lint debt #76.