### PR TITLE
ci(cflite): make build-only — drop unrunnable run_fuzzers step (#75)

### DIFF
--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -21,6 +21,13 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: javascript
+          # Skip OSS-Fuzz `check_build` (#75) — same rationale as
+          # cflite_pr.yml: our targets are differential/grammar drivers,
+          # not libFuzzer/Jazzer binaries, so `find_fuzz_targets` rejects
+          # them ("No fuzz targets found"). CFL presence earns the
+          # Scorecard Fuzzing credit; real coverage is the nightly
+          # fuzz.yml. See cflite_pr.yml for the full explanation.
+          bad-build-check: false
       - name: Run fuzzers
         id: run
         if: steps.build.outcome == 'success'

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -13,26 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-    continue-on-error: true
     steps:
       - name: Build fuzzers
-        id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: javascript
-          # Skip OSS-Fuzz `check_build` (#75) — same rationale as
-          # cflite_pr.yml: our targets are differential/grammar drivers,
-          # not libFuzzer/Jazzer binaries, so `find_fuzz_targets` rejects
-          # them ("No fuzz targets found"). CFL presence earns the
-          # Scorecard Fuzzing credit; real coverage is the nightly
-          # fuzz.yml. See cflite_pr.yml for the full explanation.
+          # Build-only by design (#75) — same rationale as cflite_pr.yml:
+          # our targets are differential/grammar drivers, not
+          # libFuzzer/Jazzer binaries, so CFL can build them but cannot
+          # run them ("No fuzz targets found"). The `run_fuzzers` step is
+          # therefore removed; the real coverage run is the nightly
+          # radamsa harness in fuzz.yml. This nightly build is kept as an
+          # early-warning canary for drift in CFL's mutable `:v1` runner
+          # base image — it goes HONESTLY red (no continue-on-error) if
+          # the CFL build path ever breaks. Scorecard Fuzzing credit keys
+          # on .clusterfuzzlite/Dockerfile presence, not this workflow.
           bad-build-check: false
-      - name: Run fuzzers
-        id: run
-        if: steps.build.outcome == 'success'
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 600
-          mode: batch

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -16,40 +16,34 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    continue-on-error: true
     steps:
       - name: Build fuzzers
-        id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: javascript
-          # Skip OSS-Fuzz's post-build `check_build` (#75). Our three
-          # targets (radamsa-urls.sh, html-grammar.mjs,
-          # unicode-confusables.mjs) are differential/grammar drivers, NOT
-          # libFuzzer/Jazzer-instrumented binaries. Under
-          # FUZZING_ENGINE=libfuzzer, `find_fuzz_targets` requires the
-          # `LLVMFuzzerTestOneInput` magic string AND then executes each
-          # target checking for edge coverage; thin shell/node wrappers
-          # satisfy neither, so the check has failed "No fuzz targets
-          # found" on EVERY run since this workflow existed (masked by
-          # continue-on-error). The CFL layout here earns the OpenSSF
-          # Scorecard Fuzzing credit (config + workflow presence); the
-          # real coverage run is the nightly fuzz.yml (radamsa from
-          # source). Disabling the libFuzzer build validation is the
-          # honest reflection of that — one line, reverts cleanly.
+          # Build-only by design (#75). Our three targets
+          # (radamsa-urls.sh, html-grammar.mjs, unicode-confusables.mjs)
+          # are differential/grammar drivers, NOT libFuzzer/Jazzer
+          # binaries. Under FUZZING_ENGINE=libfuzzer, CFL's
+          # `find_fuzz_targets` requires the `LLVMFuzzerTestOneInput` magic
+          # string AND edge-coverage instrumentation; our thin shell/node
+          # wrappers have neither, so it returns "No fuzz targets found" —
+          # which broke BOTH the post-build `check_build` AND `run_fuzzers`
+          # on every run since this workflow existed (previously masked by
+          # continue-on-error). So we:
+          #   - skip the libFuzzer build validation (bad-build-check),
+          #   - run NO `run_fuzzers` step (nothing is libFuzzer-runnable;
+          #     forcing detection would only feed the wrappers libFuzzer
+          #     args they ignore, producing no real coverage). The real
+          #     coverage run is the nightly radamsa harness in fuzz.yml.
+          # This step still genuinely validates that
+          # .clusterfuzzlite/{Dockerfile,build.sh} compile and emit the
+          # harness — so it stays HONESTLY green (no continue-on-error).
+          # Scorecard's Fuzzing check keys on .clusterfuzzlite/Dockerfile
+          # presence, NOT on this workflow, so build-only keeps 10/10.
           bad-build-check: false
-          # Our three fuzz targets are thin wrappers generated at compile
-          # time from build.sh; they do not sit one-to-one against a
-          # source file CFL's affected-detection can match. Without this
-          # flag `mode: code-change` deletes ALL targets on any PR that
-          # does not touch tests/fuzz/**, which permanently breaks the
-          # build with "No fuzz targets found in out dir" (#50).
+          # Build all three targets regardless of which files the PR
+          # touched. Without this, CFL's affected-target detection prunes
+          # the compile-time-generated wrappers to an empty $OUT on any PR
+          # that doesn't touch tests/fuzz/** (#50).
           keep-unaffected-fuzz-targets: true
-      - name: Run fuzzers
-        id: run
-        if: steps.build.outcome == 'success'
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 120
-          mode: code-change

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -23,6 +23,21 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: javascript
+          # Skip OSS-Fuzz's post-build `check_build` (#75). Our three
+          # targets (radamsa-urls.sh, html-grammar.mjs,
+          # unicode-confusables.mjs) are differential/grammar drivers, NOT
+          # libFuzzer/Jazzer-instrumented binaries. Under
+          # FUZZING_ENGINE=libfuzzer, `find_fuzz_targets` requires the
+          # `LLVMFuzzerTestOneInput` magic string AND then executes each
+          # target checking for edge coverage; thin shell/node wrappers
+          # satisfy neither, so the check has failed "No fuzz targets
+          # found" on EVERY run since this workflow existed (masked by
+          # continue-on-error). The CFL layout here earns the OpenSSF
+          # Scorecard Fuzzing credit (config + workflow presence); the
+          # real coverage run is the nightly fuzz.yml (radamsa from
+          # source). Disabling the libFuzzer build validation is the
+          # honest reflection of that — one line, reverts cleanly.
+          bad-build-check: false
           # Our three fuzz targets are thin wrappers generated at compile
           # time from build.sh; they do not sit one-to-one against a
           # source file CFL's affected-detection can match. Without this


### PR DESCRIPTION
## What

Make the two ClusterFuzzLite workflows (`cflite_pr.yml`, `cflite_cron.yml`) **build-only** and **honestly green**.

## Why `#75` was real (and why the original premise was wrong)

`#75` was filed as a *regression* / mutable `:v1` base-image drift. **That premise is wrong** — verified against the failing run's log (run `27252082931`): the build **succeeds** (radamsa compiles from source; the Dockerfile is digest-pinned, no drift). The actual failure is `find_fuzz_targets` returning **"No fuzz targets found"**, on **every run since the workflow existed**, masked by `continue-on-error: true`.

Root cause: our three targets (`radamsa-urls.sh`, `html-grammar.mjs`, `unicode-confusables.mjs`) are differential/grammar drivers, **not** libFuzzer/Jazzer-instrumented binaries. Under `FUZZING_ENGINE=libfuzzer`, CFL's `find_fuzz_targets` requires the `LLVMFuzzerTestOneInput` magic string **and** edge-coverage instrumentation; thin shell/node wrappers have neither. This broke **both** the post-build `check_build` **and** `run_fuzzers`.

## Fix (two parts — the second is what makes it complete)

1. `bad-build-check: false` on `build_fuzzers` — skips the libFuzzer instrumentation validation so the **Build** step passes (it still genuinely validates that `.clusterfuzzlite/{Dockerfile,build.sh}` compile and emit the harness).
2. **Remove the `run_fuzzers` step** from both workflows, and **drop `continue-on-error`**. `run_fuzzers` calls `find_fuzz_targets` independently — `bad-build-check` does not touch it — so it kept failing "No fuzz targets found", just one step lower. Nothing here is libFuzzer-runnable (forcing detection would only feed the wrappers libFuzzer args they ignore → no real coverage). The **real** coverage run is the nightly radamsa harness in `fuzz.yml`. `cflite_cron` is kept as a build-only canary for CFL `:v1` base-image drift; it also drops the now-unneeded `issues: write` permission.

## Scorecard impact: none

Scorecard's Fuzzing check keys on `.clusterfuzzlite/Dockerfile` **presence** (verified against scorecard v5 `checks/raw/fuzzing.go` `checkCFLite`, glob `.clusterfuzzlite/Dockerfile`), **not** on any workflow running or passing. Live API confirms the repo currently scores `Fuzzing: 10 "ClusterFuzzLite integration found"`. Build-only keeps the 10/10.

## Verification

`cflite_cron` `workflow_dispatch` against this branch (HEAD `05a90a6`), run **`27278597200`**:

```
batch-fuzzing :: Set up job      -> success
batch-fuzzing :: Pull build img  -> success
batch-fuzzing :: Build fuzzers   -> success
batch-fuzzing :: Complete job    -> success
job conclusion                   -> success   (no Run step, no continue-on-error masking)
```

`actionlint` clean on both workflow files. `cflite_pr.yml` is `pull_request`-triggered on `skills/**`/`tests/fuzz/**`/`.clusterfuzzlite/**` only, so a workflow-file-only PR does not trigger it — the cron dispatch is the equivalent build-path proxy (same `build_fuzzers` step + flags).

## Revert

`git revert <squash-sha>` restores the prior workflows verbatim (one PR, ≤1 service, CI config only).

Closes #75.