### PR TITLE
ci: bump codeql-action to v4.36.3 (init/analyze/upload atomic)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
       - name: Perform analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/shellcheck-sarif.yml
+++ b/.github/workflows/shellcheck-sarif.yml
@@ -89,7 +89,7 @@ jobs:
           echo "SARIF document written ($(wc -c < shellcheck.sarif) bytes)."
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: shellcheck.sarif
           category: shellcheck


### PR DESCRIPTION
Atomic bump of all \`github/codeql-action/*\` refs (init + analyze + upload-sarif) to v4.36.3 (\`54f647b7e1bb85c95cddabcd46b0c578ec92bc1a\`).

Dependabot split these into separate per-subaction PRs; merging one at a time skews the shared CodeQL version and breaks analysis (`Loaded a configuration file for version X, but running version Y`). This bumps all three together to restore consistency. Supersedes the split Dependabot PRs.