### PR TITLE
ci: group github-actions dependabot bumps to prevent codeql skew

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+    # Group all minor/patch action bumps into ONE PR. Without this,
+    # Dependabot splits github/codeql-action/{init,analyze,upload-sarif}
+    # into separate PRs; the three subactions share one version, so
+    # merging one at a time skews CodeQL ("Loaded config for version X,
+    # running version Y") and breaks analysis on main. Majors stay
+    # separate for deliberate review.
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "npm"
     directory: "/tests/integration"


### PR DESCRIPTION
Adds a `groups` block to the github-actions ecosystem so all minor/patch action bumps land in ONE PR instead of one-per-action.

**Root cause this fixes:** Dependabot splits `github/codeql-action/{init,analyze,upload-sarif}` into three separate PRs. The three subactions are subdirectories of one repo sharing a single version tag — merging one at a time skews CodeQL ("Loaded a configuration file for version X, but running version Y") and breaks analysis on main. Grouping lands them together. Majors stay separate for deliberate review.

Config-only; no workflow or runtime change.